### PR TITLE
Continuous integration via GitHub Actions.

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -1,0 +1,138 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: ON
+  CTEST_PARALLEL_LEVEL: 2
+
+jobs:
+  ####################
+  # Linux / macOS
+  ####################
+
+  Unix:
+    name: ${{ matrix.name }} (${{ matrix.config }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, macos-11]
+        config: [Debug, Release]
+        include:
+          - os: macos-11
+            name: macOS
+          - os: ubuntu-20.04
+            name: Linux
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 10
+
+      - name: Dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+            sudo apt-get update
+            sudo apt-get install \
+              xorg-dev  \
+              ccache
+
+      - name: Dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install ccache
+
+      - name: Cache Build
+        id: cache-build
+        uses: actions/cache@v2
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-${{ matrix.config }}-cache
+
+      - name: Prepare ccache
+        run: |
+          ccache --max-size=1.0G
+          ccache -V && ccache --show-stats && ccache --zero-stats
+
+      - name: Configure
+        run: |
+          mkdir -p build
+          cd build
+          cmake .. \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
+
+      - name: Build
+        run: cd build; make -j2; ccache --show-stats
+
+      - name: Tests
+        run: cd build; ctest --verbose -j2
+
+  ####################
+  # Windows
+  ####################
+
+  Windows:
+    name: Windows (${{ matrix.config }})
+    runs-on: windows-2022
+    env:
+      CC: cl.exe
+      CXX: cl.exe
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [Debug, Release]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 10
+
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install Ninja
+        uses: seanmiddleditch/gha-setup-ninja@master
+
+      - name: Set env variable for sccache
+        run: |
+          echo "appdata=$env:LOCALAPPDATA" >> ${env:GITHUB_ENV}
+
+      - name: Cache build
+        id: cache-build
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.appdata }}\Mozilla\sccache
+          key: ${{ runner.os }}-${{ matrix.config }}-cache
+
+      - name: Prepare sccache
+        run: |
+          Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+          scoop install sccache --global
+          # Scoop modifies the PATH so we make it available for the next steps of the job
+          echo "${env:PATH}" >> ${env:GITHUB_PATH}
+
+      - name: Configure
+        run: |
+          cmake -G Ninja `
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache `
+            -DCMAKE_BUILD_TYPE=${{ matrix.config }} `
+            -DCMAKE_JOB_POOLS="pool-linking=1;pool-compilation=2" `
+            -DCMAKE_JOB_POOL_COMPILE:STRING=pool-compilation `
+            -DCMAKE_JOB_POOL_LINK:STRING=pool-linking `
+            -B build `
+            -S .
+
+      - name: Build
+        run: cmake --build build -j2
+
+      - name: Tests
+        run: cd build; ctest --verbose -j2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,178 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron:  '0 4 * * *'
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: ON
+  CTEST_PARALLEL_LEVEL: 2
+
+jobs:
+  check_date:
+    runs-on: ubuntu-20.04
+    name: Check latest commit
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: print latest_commit
+        run: echo ${{ github.sha }}
+
+      - id: should_run
+        continue-on-error: true
+        name: check latest commit is less than a day
+        if: ${{ github.event_name == 'schedule' }}
+        run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "::set-output name=should_run::false"
+
+  ####################
+  # Linux / macOS
+  ####################
+
+  Unix:
+    name: ${{ matrix.name }} (${{ matrix.config }})
+    runs-on: ${{ matrix.os }}
+    needs: check_date
+    if: ${{ needs.check_date.outputs.should_run != 'false' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [
+          ubuntu-20.04-gcc-8,
+          ubuntu-20.04-gcc-9,
+          ubuntu-20.04-gcc-10,
+          ubuntu-20.04-gcc-11,
+          ubuntu-20.04-clang-9,
+          ubuntu-20.04-clang-10,
+          ubuntu-20.04-clang-11,
+          ubuntu-20.04-clang-12,
+          macos-10.15,
+          macOS-11,
+        ]
+        config: [Debug, Release]
+        include:
+          - name: ubuntu-20.04-gcc-8
+            os: ubuntu-20.04
+            compiler: gcc
+            version: "8"
+
+          - name: ubuntu-20.04-gcc-9
+            os: ubuntu-20.04
+            compiler: gcc
+            version: "9"
+
+          - name: ubuntu-20.04-gcc-10
+            os: ubuntu-20.04
+            compiler: gcc
+            version: "10"
+
+          - name: ubuntu-20.04-gcc-11
+            os: ubuntu-20.04
+            compiler: gcc
+            version: "11"
+
+          - name: ubuntu-20.04-clang-9
+            os: ubuntu-20.04
+            compiler: clang
+            version: "9"
+
+          - name: ubuntu-20.04-clang-10
+            os: ubuntu-20.04
+            compiler: clang
+            version: "10"
+
+          - name: ubuntu-20.04-clang-11
+            os: ubuntu-20.04
+            compiler: clang
+            version: "11"
+
+          - name: ubuntu-20.04-clang-12
+            os: ubuntu-20.04
+            compiler: clang
+            version: "12"
+
+          - name: macOS-10.15
+            os: macOS-10.15
+
+          - name: macOS-11
+            os: macOS-11
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 10
+
+      - name: Dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+            sudo apt-get update
+
+            if [ "${{ matrix.compiler }}" = "gcc" ]; then
+              sudo apt-get install -y g++-${{ matrix.version }}
+              echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
+              echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
+            else
+              sudo apt-get install -y clang-${{ matrix.version }}
+              echo "CC=clang-${{ matrix.version }}" >> $GITHUB_ENV
+              echo "CXX=clang++-${{ matrix.version }}" >> $GITHUB_ENV
+            fi
+
+            sudo apt-get install \
+              xorg-dev
+
+      - name: Configure
+        run: |
+          mkdir -p build
+          cd build
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+
+      - name: Build
+        run: cd build; make -j2
+
+      - name: Tests
+        run: cd build; ctest --verbose -j2
+
+  ####################
+  # Windows
+  ####################
+
+  Windows:
+    name: Windows (${{ matrix.config }})
+    runs-on: windows-2022
+    needs: check_date
+    if: ${{ needs.check_date.outputs.should_run != 'false' }}
+    env:
+      CC: cl.exe
+      CXX: cl.exe
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [Debug, Release]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 10
+
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install Ninja
+        uses: seanmiddleditch/gha-setup-ninja@master
+
+      - name: Configure
+        run: |
+          cmake -G Ninja `
+            -DCMAKE_BUILD_TYPE=${{ matrix.config }} `
+            -DCMAKE_JOB_POOLS="pool-linking=1;pool-compilation=2" `
+            -DCMAKE_JOB_POOL_COMPILE:STRING=pool-compilation `
+            -DCMAKE_JOB_POOL_LINK:STRING=pool-linking `
+            -B build `
+            -S .
+
+      - name: Build
+        run: cmake --build build -j2
+
+      - name: Tests
+        run: cd build; ctest --verbose -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 2.8.11)
 
 # Note: geogram.cmake defines GEOGRAM_WITH_VORPALINE
 # that we could have used instead,
-# but geogram.cmake needs to be included after the project() 
+# but geogram.cmake needs to be included after the project()
 # command, since project() resets CFLAGS and CXXFLAGS.
 
 if("$ENV{GEOGRAM_WITH_VORPALINE}" STREQUAL "")
@@ -42,7 +42,7 @@ if(NOT GEOGRAM_SUB_BUILD)
    option(GEOGRAM_WITH_FPG "Predicate generator (Sylvain Pion's FPG)" OFF)
    option(GEOGRAM_USE_SYSTEM_GLFW3 "Use the version of GLFW3 installed in the system if found" OFF)
    option(GEOGRAM_WITH_GARGANTUA "64-bit indices" OFF)
-   set(VORPALINE_PLATFORM "" CACHE STRING "")
+   include(cmake/geo_detect_platform.cmake)
 endif()
 
 include(cmake/geogram.cmake)
@@ -76,13 +76,13 @@ endif()
 if(GEOGRAM_WITH_VORPALINE)
    find_package(Subversion QUIET)
    if(NOT SUBVERSION_FOUND)
-       message(WARNING "Subversion executable not found - cannot determine current revision") 
+       message(WARNING "Subversion executable not found - cannot determine current revision")
    else()
        Subversion_WC_INFO(${PROJECT_SOURCE_DIR} Vorpaline)
        message(STATUS "Vorpaline revision is ${Vorpaline_WC_REVISION}")
        set(VORPALINE_SVN_REVISION ${Vorpaline_WC_REVISION})
    endif()
-endif()   
+endif()
 
 ##############################################################################
 # RPATH (where executables find the .so / DLLs)
@@ -181,7 +181,7 @@ if(CPACK_GENERATOR STREQUAL "DEB")
 #   or GET_PROPERTY(result GLOBAL ENABLED_FEATURES)  (successful FIND_PACKAGE())
 endif()
 
-if(NOT DEFINED CPACK_GENERATOR) 
+if(NOT DEFINED CPACK_GENERATOR)
   if(WIN32)
     set(CPACK_GENERATOR ZIP)
   else()

--- a/cmake/geo_detect_platform.cmake
+++ b/cmake/geo_detect_platform.cmake
@@ -1,0 +1,21 @@
+
+# Sets the CACHE variable VORPALINE_PLATFORM based on the detected operating system.
+#
+# Note that it would be better to use CMAKE_SYSTEM_NAME directly, and use other CMake
+# variables to enable other build-specific flags, e.g.:
+# - Use BUILD_SHARED_LIBS to enable behavior specific to shared libs
+# - Use CheckCXXCompilerFlag to enable compiler-specific flags
+#
+if(CMAKE_SYSTEM_NAME MATCHES Linux)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        set(VORPALINE_PLATFORM "Linux64-gcc-dynamic" CACHE STRING "")
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(VORPALINE_PLATFORM "Linux64-clang-dynamic" CACHE STRING "")
+    endif()
+elseif(CMAKE_SYSTEM_NAME MATCHES Darwin)
+    set(VORPALINE_PLATFORM "Darwin-clang-dynamic" CACHE STRING "")
+elseif(CMAKE_SYSTEM_NAME MATCHES Windows)
+    set(VORPALINE_PLATFORM "Win-vs-generic" CACHE STRING "")
+elseif(CMAKE_SYSTEM_NAME MATCHES Android)
+    set(VORPALINE_PLATFORM "Android-aarch64-gcc-dynamic" CACHE STRING "")
+endif()

--- a/cmake/geogram.cmake
+++ b/cmake/geogram.cmake
@@ -9,9 +9,9 @@ if(EXISTS ${GEOGRAM_SOURCE_DIR}/CMakeOptions.txt)
 endif()
 
 # Make sure that VORPALINE_PLATFORM is defined
-if(NOT DEFINED VORPALINE_PLATFORM)
-     if(WIN32) 
-        message( 
+if(NOT VORPALINE_PLATFORM)
+     if(WIN32)
+        message(
            STATUS
            " Using Win-vs-generic (default),\n"
            " (if need be, use CMake variable VORPALINE_PLATFORM to override)."
@@ -39,7 +39,7 @@ endif()
 
 if ("${GEOGRAM_WITH_VORPALINE}" STREQUAL ON)
    message(STATUS "Configuring build for Geogram + Vorpaline")
-   add_definitions(-DGEOGRAM_WITH_VORPALINE)  
+   add_definitions(-DGEOGRAM_WITH_VORPALINE)
 else()
    message(STATUS "Configuring build for standalone Geogram (without Vorpaline)")
 endif()
@@ -105,14 +105,19 @@ string(REPLACE ${CMAKE_SOURCE_DIR} "" RELATIVE_OUTPUT_DIR ${CMAKE_BINARY_DIR})
 # as an output (does not include configuration name under MSVC, because
 # MSVC adds it automatically, thus it would be there twice if we add it).
 # This is where plugins are supposed to copy their generated DLL's/so's.
+#
+# Note: Ideally one should use the generator expressions TARGET_FILE_DIR
+# and TARGET_RUNTIME_DLLS to copy runtime dependencies as a post-build
+# action. See for example:
+# https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#genex:TARGET_RUNTIME_DLLS
 
-if(WIN32)
-        set(MSVC_CONFIG \$\(Configuration\))
-        set(RELATIVE_BIN_DIR ${RELATIVE_OUTPUT_DIR}/bin/${MSVC_CONFIG}/)
-        set(RELATIVE_LIB_DIR ${RELATIVE_OUTPUT_DIR}/lib/${MSVC_CONFIG}/)
+if(WIN32 AND GENERATOR_IS_MULTI_CONFIG)
+    set(MSVC_CONFIG \$\(Configuration\))
+    set(RELATIVE_BIN_DIR ${RELATIVE_OUTPUT_DIR}/bin/${MSVC_CONFIG}/)
+    set(RELATIVE_LIB_DIR ${RELATIVE_OUTPUT_DIR}/lib/${MSVC_CONFIG}/)
 else()
-        set(RELATIVE_BIN_DIR ${RELATIVE_OUTPUT_DIR}/bin/)
-        set(RELATIVE_LIB_DIR ${RELATIVE_OUTPUT_DIR}/lib/)
+    set(RELATIVE_BIN_DIR ${RELATIVE_OUTPUT_DIR}/bin/)
+    set(RELATIVE_LIB_DIR ${RELATIVE_OUTPUT_DIR}/lib/)
 endif()
 
 set(RELATIVE_BIN_OUTPUT_DIR ${RELATIVE_OUTPUT_DIR}/bin/)

--- a/cmake/platforms/Linux-clang.cmake
+++ b/cmake/platforms/Linux-clang.cmake
@@ -4,10 +4,6 @@
 
 include(${GEOGRAM_SOURCE_DIR}/cmake/platforms/Linux.cmake)
 
-# Set the Clang compilers
-set(CMAKE_C_COMPILER "/usr/bin/clang-3.8" CACHE string "clang compiler" FORCE)
-set(CMAKE_CXX_COMPILER "/usr/bin/clang++-3.8" CACHE string "clang compiler" FORCE)
-
 # Warning flags
 set(NORMAL_WARNINGS -Wall -Wextra)
 
@@ -31,7 +27,7 @@ if(VORPALINE_WITH_CLANGSA)
 endif()
 
 # I do not know where this -Wno-maybe-uninitialized comes from
-# (but clang does not understand it), silence the warning for 
+# (but clang does not understand it), silence the warning for
 # now...
 add_flags(CMAKE_CXX_FLAGS -Wno-unknown-warning-option)
 add_flags(CMAKE_C_FLAGS -Wno-unknown-warning-option)

--- a/cmake/platforms/Windows-vs.cmake
+++ b/cmake/platforms/Windows-vs.cmake
@@ -53,6 +53,12 @@ remove_flags(CMAKE_C_FLAGS_DEBUG /GZ)
 # GX is deprecated (replaced by EHsc)
 remove_flags(CMAKE_CXX_FLAGS /GX)
 
+# https://github.com/mozilla/sccache/issues/242
+if(CMAKE_CXX_COMPILER_LAUNCHER STREQUAL "sccache")
+    string(REGEX REPLACE "/Z[iI7]" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Z7")
+endif()
+
 # Change flags for static link
 if(VORPALINE_BUILD_DYNAMIC)
 # remove warning for multiply defined symbols (caused by multiple
@@ -103,4 +109,4 @@ endfunction()
 macro(vor_add_executable)
     add_executable(${ARGN})
 endmacro()
- 
+


### PR DESCRIPTION
- Adds a PR check + nightly job via GitHub Actions.
- Runs on Windows/macOS/Linux. Currently missing: Android, Emscripten, MinGW and Linux-ICC
- Currently no unit tests are run. Not sure what you want to do there?

To facilitate CMake maintenance, I'd recommend the following:
- Get rid of `configure.sh` and `configure.bat`. Platforms can be detected directly via CMake (see new file `geo_detect_platform.cmake`.
- There are a lot of files in `cmake/platforms.cmake`, which seems like a pain to maintain. I'd recommend keeping a single `platforms/Windows.cmake` and a single `platforms/Unix.cmake` and use `check_cxx_compiler_flag` to check for compiler support for specific flags across all possible GCC/clang versions.

Continuous PR check:
![Screen Shot 2022-02-27 at 6 23 10 PM](https://user-images.githubusercontent.com/578702/155913771-5ed83158-ad85-4527-837b-89f8b0bb904c.png)

Nightly check:
![Screen Shot 2022-02-27 at 5 59 34 PM](https://user-images.githubusercontent.com/578702/155912061-0968495a-90c0-455f-b6d6-66f7e137d21d.png)