### PR TITLE
Fix CMakeLists for using geogram as a dependency

### DIFF
--- a/src/lib/geogram/CMakeLists.txt
+++ b/src/lib/geogram/CMakeLists.txt
@@ -38,7 +38,7 @@ add_library(geogram ${SOURCES} $<TARGET_OBJECTS:geogram_third_party>)
 # path for targets that depend on geogram.
 # See: https://cmake.org/cmake/help/v3.3/command/target_include_directories.html
 # https://stackoverflow.com/questions/26243169/cmake-target-include-directories-meaning-of-scope
-target_include_directories(geogram PUBLIC ${GEOGRAM_PATH}/src/lib) 
+target_include_directories(geogram PUBLIC ${PROJECT_SOURCE_DIR}/src/lib) 
 
 if(ANDROID)
   target_include_directories(geogram PRIVATE


### PR DESCRIPTION
`GEOGRAM_PATH` is not defined anywhere else in the project. This fix allows headers to be found by top-level project using geogram as a direct CMake dependency via [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html).

> [PROJECT_SOURCE_DIR](https://cmake.org/cmake/help/latest/variable/PROJECT_SOURCE_DIR.html)
> This is the source directory of the last call to the [project()](https://cmake.org/cmake/help/latest/command/project.html#command:project) command made in the current directory scope or one of its parents.