### PR TITLE
Fix C++20 Compilation of memory.h header

### DIFF
--- a/src/lib/geogram/basic/memory.h
+++ b/src/lib/geogram/basic/memory.h
@@ -512,7 +512,7 @@ namespace GEO {
              * \return A pointer to the initial element in the block of storage
              */
             pointer allocate(
-                size_type nb_elt, ::std::allocator<void>::const_pointer hint = nullptr
+                size_type nb_elt, const void* hint = nullptr
             ) {
                 geo_argused(hint);
                 pointer result = static_cast<pointer>(
@@ -545,7 +545,7 @@ namespace GEO {
              */
             size_type max_size() const {
                 ::std::allocator<char> a;
-                return a.max_size() / sizeof(T);
+                return std::allocator_traits<decltype(a)>::max_size(a) / sizeof(T);
             }
 
             /**


### PR DESCRIPTION
Minor changes are required to compile the Geogram library with C++20: Removing occurrences of deprecated/removed functions from [std::Allocator](https://en.cppreference.com/w/cpp/memory/allocator).

Tested compilation on GCC 12.1 and Clang 14 for C++20 compilation
Tested compatibility with older compilers with GCC 7.5 with default compilation options

Those changes may not be sufficient to compile the whole code-base in C++20. At least, most headers of the Geogram library can be included in a C++20-based project with this change