### PR TITLE
CMake: Fix build on Android NDK

### DIFF
--- a/cmake/platforms/Android-aarch64-clang.cmake
+++ b/cmake/platforms/Android-aarch64-clang.cmake
@@ -4,10 +4,6 @@
 
 include(${GEOGRAM_SOURCE_DIR}/cmake/platforms/Linux.cmake)
 
-# Set the Android compilers
-set(CMAKE_CXX_COMPILER aarch64-linux-android-clang++)
-set(CMAKE_C_COMPILER aarch64-linux-android-clang)
-
 set(VORPALINE_ARCH_64 true)
 
 # No graphics (yet) for Android

--- a/cmake/platforms/Android-aarch64-clang.cmake
+++ b/cmake/platforms/Android-aarch64-clang.cmake
@@ -50,10 +50,6 @@ add_flags(CMAKE_EXE_LINKER_FLAGS ${ARCH_FLAGS} -pie)
 # deactivated for now: I added bound checking in VOR::vector<>.
 #add_flags(CMAKE_CXX_FLAGS_DEBUG -D_GLIBCXX_DEBUG)
 
-# Compile and link with pthreads
-add_flags(CMAKE_CXX_FLAGS -pthread)
-add_flags(CMAKE_C_FLAGS -pthread)
-
 # Profiler compilation flags
 if(VORPALINE_WITH_GPROF)
     message(STATUS "Building for code profiling")

--- a/src/lib/geogram/CMakeLists.txt
+++ b/src/lib/geogram/CMakeLists.txt
@@ -59,7 +59,11 @@ set_target_properties(geogram PROPERTIES
 		      FOLDER "GEOGRAM")
 
 if(UNIX AND VORPALINE_BUILD_DYNAMIC)
-    target_link_libraries(geogram pthread dl)
+    if (ANDROID)
+        target_link_libraries(geogram dl)
+    else()
+        target_link_libraries(geogram pthread dl)
+    endif()
 endif()
 
 if(WIN32)


### PR DESCRIPTION
Android NDK does not have executables in the format of aarch64-linux-android-clang++. Instead it provides executables in the format aarch64-linux-android${ANDROID_ABI}-clang++. Since CMake 3.21 all of this is handled by the toolchain file within Android NDK itself, so there is no need to override the compilers anymore.

Additionally, on Android pthread functionality is built into the C library and linking to pthread is not only needed but results in link failures.