### PR TITLE
Use internal linkage for symbols from stb_image.h

### DIFF
--- a/src/lib/geogram/image/image_serializer_stb.cpp
+++ b/src/lib/geogram/image/image_serializer_stb.cpp
@@ -44,6 +44,11 @@
 #define STB_IMAGE_IMPLEMENTATION
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 
+// Use internal linkage for symbols from stb_image as it is a very commonly embedded library.
+// Making these symbols visible  causes duplicate symbol problems if geogram is linked
+// statically together with another library or executable that also embeds stb_image.
+#define STB_IMAGE_STATIC
+
 // [Bruno] I got too many complaints in STB so I "close my eyes" :-)
 #ifdef __GNUC__
 #ifndef __ICC


### PR DESCRIPTION
This makes it possible to link geogram statically into an executable with another static library that includes stb_image.h without hiding its symbols.