### PR TITLE
Use standard library functions for random number generator

### DIFF
--- a/src/lib/geogram/basic/numeric.cpp
+++ b/src/lib/geogram/basic/numeric.cpp
@@ -40,6 +40,8 @@
 #include <geogram/basic/numeric.h>
 #include <stdlib.h>
 
+#include <random>
+
 #ifdef GEO_COMPILER_EMSCRIPTEN
 #pragma GCC diagnostic ignored "-Wc++11-long-long"
 #endif
@@ -47,6 +49,8 @@
 namespace GEO {
 
     namespace Numeric {
+        
+        static std::mt19937_64 random_engine;
 
         bool is_nan(float32 x) {
 #ifdef GEO_COMPILER_MSVC
@@ -65,47 +69,19 @@ namespace GEO {
         }
 
         void random_reset() {
-#ifdef GEO_OS_WINDOWS
-            srand(1);
-#else
-            srandom(1);
-#endif
+            random_engine = {};
         }
 
         int32 random_int32() {
-#ifdef GEO_OS_WINDOWS
-            return rand();
-#else
-            return int32(random() % std::numeric_limits<int32>::max());
-#endif
+            return std::uniform_int_distribution<int32>(0, RAND_MAX)(random_engine);
         }
 
         float32 random_float32() {
-#if defined(GEO_OS_WINDOWS)
-            return float(rand()) / float(RAND_MAX);
-#elif defined(GEO_OS_ANDROID)
-            // TODO: find a way to call drand48()
-            // (problem at link time)
-            return
-                float(random_int32()) /
-                float(std::numeric_limits<int32>::max());
-#else
-            return float(drand48());
-#endif
+            return std::uniform_real_distribution<float32>(0, 1)(random_engine);
         }
 
         float64 random_float64() {
-#if defined(GEO_OS_WINDOWS)
-            return double(rand()) / double(RAND_MAX);
-#elif defined(GEO_OS_ANDROID)
-            // TODO: find a way to call drand48()
-            // (problem at link time)
-            return
-                double(random_int32()) /
-                double(std::numeric_limits<int32>::max());
-#else
-            return double(drand48());
-#endif
+            return std::uniform_real_distribution<float64>(0, 1)(random_engine);
         }
     }
 }


### PR DESCRIPTION
Hi,

First of all, great library and good work!
I am using geogram mainly on Windows with MSVC and found an interesting edge case when computing RVDs on high polycount meshes. In contrast to GCC, the constant `RAND_MAX` is only `0x7fff` on MSVC, which caused an unevenly distributed sampling to be generated in `compute_initial_sampling`.

Initial sampling with current code (input: [Nefretiti](https://github.com/odedstein/meshes/tree/master/objects/nefertiti) with ~2M faces, nb_points=500,000 )

![image](https://github.com/BrunoLevy/geogram/assets/9591359/0f63d7f6-e92b-48b6-8807-d774df224dac)

I replaced the `rand()\srand()` functions in `numeric.cpp` with a c++11 random engine and the distribution was much more even:

![image](https://github.com/BrunoLevy/geogram/assets/9591359/b211e8e3-9b9d-4e62-b558-20152bfee7d7)

In some remeshing cases, this uneven initial sampling meant that I had to use a higher number of iterations or the solution did not converge.

If possible, could we replace the random generator functions with the ones from the C++ standard library, or at least with one that has higher entropy and is not toolset-specific? I am not sure what the minimum compiler support is for you.

Thank you and best regards,

Michael
