### PR TITLE
Fix 'implicit-int' errors arising from Clang 16

### DIFF
--- a/src/lib/third_party/numerics/SUPERLU/cutil.c
+++ b/src/lib/third_party/numerics/SUPERLU/cutil.c
@@ -474,7 +474,7 @@ cPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 
-
+int
 print_complex_vec(char *what, int n, complex *vec)
 {
     int i;

--- a/src/lib/third_party/numerics/SUPERLU/dutil.c
+++ b/src/lib/third_party/numerics/SUPERLU/dutil.c
@@ -470,7 +470,7 @@ dPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 
-
+int
 print_double_vec(char *what, int n, double *vec)
 {
     int i;

--- a/src/lib/third_party/numerics/SUPERLU/sutil.c
+++ b/src/lib/third_party/numerics/SUPERLU/sutil.c
@@ -470,7 +470,7 @@ sPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 
-
+int
 print_float_vec(char *what, int n, float *vec)
 {
     int i;

--- a/src/lib/third_party/numerics/SUPERLU/zutil.c
+++ b/src/lib/third_party/numerics/SUPERLU/zutil.c
@@ -474,7 +474,7 @@ zPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 
-
+int
 print_doublecomplex_vec(char *what, int n, doublecomplex *vec)
 {
     int i;


### PR DESCRIPTION
Hi Bruno,

I recently upgraded my Clang version to 16, and this section resulted in an error. 
Upon investigation, I found that **-Wimplicit-int** has been escalated from a warning to an error since version 16, as mentioned in this link: [https://www.redhat.com/en/blog/new-warnings-and-errors-clang-16](https://www.redhat.com/en/blog/new-warnings-and-errors-clang-16). 
So I've fixed it.