### PR TITLE
fixup! Add support for non-x86 arches (tested on riscv64)

### DIFF
--- a/cmake/platforms/Linux64-nonx86-clang-dynamic/config.cmake
+++ b/cmake/platforms/Linux64-nonx86-clang-dynamic/config.cmake
@@ -1,6 +1,3 @@
 set(VORPALINE_ARCH_64 true)
 set(VORPALINE_BUILD_DYNAMIC true)
 include(${GEOGRAM_SOURCE_DIR}/cmake/platforms/Linux-clang.cmake)
-add_flags(CMAKE_CXX_FLAGS -m64)
-add_flags(CMAKE_C_FLAGS -m64)
-


### PR DESCRIPTION
I am dumb and forgot to commit this change in my previous PR.