### PR TITLE
fix a compilation error in src/lib/third_party/numerics/SUPERLU/

### DIFF
--- a/src/lib/third_party/numerics/SUPERLU/slacon2.c
+++ b/src/lib/third_party/numerics/SUPERLU/slacon2.c
@@ -160,7 +160,7 @@ L40:
 #ifdef _CRAY
     isave[1] = ISAMAX(n, &x[0], &c__1);   /* j */
 #else
-    isave[1] = idamax_(n, &x[0], &c__1);  /* j */
+    isave[1] = isamax_(n, &x[0], &c__1);  /* j */
 #endif
     --isave[1];  /* --j; */
     isave[2] = 2;  /* iter = 2; */


### PR DESCRIPTION
This fixes a compilation error about `float* vs `double*`.

I have ran basic tests (no sanitizer, no nothing) with:

```shell
./build/Linux64-gcc-dynamic-Release/tests/runpybot.sh --include=smoke --include=smoke_Standard tests/
```

![Screenshot_20240618_163328](https://github.com/BrunoLevy/geogram/assets/5746675/1d9d169c-1738-4887-beed-2391b3b75b97)
