### PR TITLE
Fix segmentation fault in nlEigenSolve_ARPACK

### DIFF
--- a/src/lib/geogram/NL/nl_arpack.c
+++ b/src/lib/geogram/NL/nl_arpack.c
@@ -513,6 +513,7 @@ void nlEigenSolve_ARPACK(void) {
     nlCurrentContext->temp_eigen_value = NULL;
 
     /********** Copy to NL context *********/
+
     nev_0 = min(nev_0, nev); /* enforce that no more than the requested number of eigenvalues are copied */
     for(k=0; k<nev_0; ++k) {
         kk = sorted[k];

--- a/src/lib/geogram/NL/nl_arpack.c
+++ b/src/lib/geogram/NL/nl_arpack.c
@@ -391,6 +391,7 @@ void nlEigenSolve_ARPACK(void) {
     workl = NL_NEW_ARRAY(NLdouble, lworkl);
 
     /********** Main ARPACK loop ***********/
+    int nev_0 = nev; //Save the original requested value in case ARPack increments it
 
     if(nlCurrentContext->verbose) {
         if(symmetric) {
@@ -512,8 +513,8 @@ void nlEigenSolve_ARPACK(void) {
     nlCurrentContext->temp_eigen_value = NULL;
 
     /********** Copy to NL context *********/
-
-    for(k=0; k<nev; ++k) {
+    nev_0 = min(nev_0, nev);
+    for(k=0; k<nev_0; ++k) {
         kk = sorted[k];
         nlCurrentContext->eigen_value[k] = d[kk];
         for(i=0; i<(int)nlCurrentContext->nb_variables; ++i) {

--- a/src/lib/geogram/NL/nl_arpack.c
+++ b/src/lib/geogram/NL/nl_arpack.c
@@ -391,8 +391,8 @@ void nlEigenSolve_ARPACK(void) {
     workl = NL_NEW_ARRAY(NLdouble, lworkl);
 
     /********** Main ARPACK loop ***********/
-    int nev_0 = nev; /* save the requested number of eigenvalues in case ARPack modifies the value of nev */
 
+    int nev_0 = nev; /* save the requested number of eigenvalues in case ARPack modifies the value of nev */
     if(nlCurrentContext->verbose) {
         if(symmetric) {
             nl_printf("calling dsaupd()\n");

--- a/src/lib/geogram/NL/nl_arpack.c
+++ b/src/lib/geogram/NL/nl_arpack.c
@@ -391,7 +391,7 @@ void nlEigenSolve_ARPACK(void) {
     workl = NL_NEW_ARRAY(NLdouble, lworkl);
 
     /********** Main ARPACK loop ***********/
-    int nev_0 = nev; //Save the original requested value in case ARPack increments it
+    int nev_0 = nev; /* save the requested number of eigenvalues in case ARPack modifies the value of nev */
 
     if(nlCurrentContext->verbose) {
         if(symmetric) {
@@ -513,7 +513,7 @@ void nlEigenSolve_ARPACK(void) {
     nlCurrentContext->temp_eigen_value = NULL;
 
     /********** Copy to NL context *********/
-    nev_0 = min(nev_0, nev);
+    nev_0 = min(nev_0, nev); /* enforce that no more than the requested number of eigenvalues are copied */
     for(k=0; k<nev_0; ++k) {
         kk = sorted[k];
         nlCurrentContext->eigen_value[k] = d[kk];


### PR DESCRIPTION
Avoid segmentation fault caused by ARPack incrementing the requested number of eigenvalues in nlEigenSolve_ARPACK. This workaround avoids the invalid access by enforcing that at most the requested number of eigenvalues are copied to the NL context.

See [this issue](https://github.com/BrunoLevy/geogram/issues/166) where the manifold_harmonics sample program crashes due to a segmentation fault with certain values of nb_eigens on Windows.