### PR TITLE
Allow to pick edges in DemoPicking

### DIFF
--- a/src/examples/graphics/demo_Picking/main.cpp
+++ b/src/examples/graphics/demo_Picking/main.cpp
@@ -191,6 +191,15 @@ namespace {
                     mesh_element_str_ = subelements_type_to_name(mesh_element_);
                 }
                 if (ImGui::Selectable(
+                        subelements_type_to_name(MESH_EDGES).c_str(),
+                        mesh_element_ == MESH_EDGES)
+                   ) {
+                    mesh_element_ = MESH_EDGES;
+                    mesh_element_str_ = subelements_type_to_name(mesh_element_);
+                    show_vertices_ = false;
+                    show_mesh_ = true;
+                }
+                if (ImGui::Selectable(
                         subelements_type_to_name(MESH_VERTICES).c_str(),
                         mesh_element_ == MESH_VERTICES)
                    ) {


### PR DESCRIPTION
PR #102 follow-up, where I wrote:
> Note: `MeshGfx::set_picking_mode()` also accepts MESH_EDGES, but I did not manage to read something other than -1.

I though edges were the facet edges (aka the wireframe), and the mesh I tested did not have [edges](https://github.com/BrunoLevy/geogram/wiki/Mesh#mesh-edges). That is why I got -1 everywhere.

By allowing MESH_EDGES for `MeshGfx::set_picking_mode()` (the 9 loc of the commit) and by loading a mesh with edges (like CAD feature edges), we can pick edge indices with the demo executable.

Outside the scope of this PR, note that the [mesh edges](https://github.com/BrunoLevy/geogram/wiki/Mesh#mesh-edges) and the mesh wireframe (facet edges) are both [toggled with `show_mesh_`](https://github.com/BrunoLevy/geogram/blob/main/src/lib/geogram_gfx/gui/simple_mesh_application.cpp#L473) and have the [same color `mesh_color_`](https://github.com/BrunoLevy/geogram/blob/main/src/lib/geogram_gfx/mesh/mesh_gfx.cpp#L383) and the [same width `mesh_width_`](https://github.com/BrunoLevy/geogram/blob/main/src/lib/geogram_gfx/mesh/mesh_gfx.cpp#L384), making difficult to distinguish them: 

![Capture d’écran du 2024-09-06 13-56-56](https://github.com/user-attachments/assets/086c81a7-b3d6-424b-bee8-4596a0aef293)
