### PR TITLE
Add LoongArch64 support

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -131,6 +131,9 @@ if [ -z "$os" ]; then
         Linux*riscv64*)
             os=Linux64-nonx86-gcc-dynamic
             ;;
+        Linux*loongarch64*)
+            os=Linux64-nonx86-gcc-dynamic
+            ;;
         Darwin*)
             os=Darwin-clang-dynamic
             ;;

--- a/src/lib/geogram/basic/common.h
+++ b/src/lib/geogram/basic/common.h
@@ -278,7 +278,7 @@ namespace GEO {
 #  error "Unsupported compiler"
 #endif
 
-#if defined(__x86_64) || defined(__ppc64__) || defined(__arm64__) || defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64)
+#if defined(__x86_64) || defined(__ppc64__) || defined(__arm64__) || defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64) || defined(__loongarch_lp64)
 #  define GEO_ARCH_64
 #else
 #  define GEO_ARCH_32

--- a/src/lib/third_party/numerics/LIBF2C/libf2c_uninit.c
+++ b/src/lib/third_party/numerics/LIBF2C/libf2c_uninit.c
@@ -288,7 +288,14 @@ which we want*/
 	__fpu_control |= (1 << 2);    // OF
 	__fpu_control |= (1 << 3);    // UF
 	_FPU_SETCW(__fpu_control);
-#else /* !(mc68000||powerpc||riscv) */
+
+#elif (defined (__loongarch__)) /* !(mc68000||powerpc||riscv) */
+	__fpu_control = _FPU_DEFAULT;
+	__fpu_control |= _FPU_MASK_V; // NV
+	__fpu_control |= _FPU_MASK_O; // OF
+	__fpu_control |= _FPU_MASK_U; // UF
+	_FPU_SETCW(__fpu_control);
+#else /* !(mc68000||powerpc||riscv||loongarch) */
 
 #ifdef _FPU_IEEE
 #ifndef _FPU_EXTENDED /* e.g., ARM processor under Linux */


### PR DESCRIPTION
[LoongArch](https://docs.kernel.org/arch/loongarch/introduction.html) is a new RISC ISA developed by loongson. There are already a lot of [community support and testing](https://www.phoronix.com/search/LoongArch) about it.

This patch adds the support of LoongArch64 for the project.

Tested on archlinux's loong64 port. Here is the [log](https://github.com/user-attachments/files/17917866/geogram-1.9.1-2-loong64-build.log).