### PR TITLE
Use cmake.exe from path, if it is found there

### DIFF
--- a/configure.bat
+++ b/configure.bat
@@ -25,7 +25,19 @@ if not exist "build\Windows%buildNameSuffix%" (
 
 cd build\Windows%buildNameSuffix%
 
-"%ProgramFiles%\cmake\bin\cmake.exe" ..\.. ^
+
+REM ----------------------------------------------------------------
+REM If cmake.exe is in path, use it.
+REM Otherwise, use fallback location.
+REM ----------------------------------------------------------------
+WHERE cmake.exe >nul 2>nul
+IF %ERRORLEVEL% NEQ 0 (
+    set "cMakeCommand=%ProgramFiles%\cmake\bin\cmake.exe"
+) else (
+    set "cMakeCommand=cmake"
+)
+
+"%cmakeCommand%" ..\.. ^
  -DVORPALINE_PLATFORM:STRING=Win-vs-dynamic-generic
 
 


### PR DESCRIPTION
This change makes `configure.bat` to use `cmake.exe` from path, if it is found there. This makes the script to work on systems that have Visual Studio installed, but no separate installation for CMake for Windows. Opening _Developer Command Prompt for VS 2022_ brings cmake bundled with Visual Studio into path.

I am not proficient with bat scripts, so someone else should verify this is a good change. It works on my machine, but I've only tested the path where `cmake.exe` is found from path.
