### PR TITLE
MeshSurfaceIntersection: Fix an issue during radius computation for normalize step

### DIFF
--- a/src/lib/geogram/mesh/mesh_surface_intersection.cpp
+++ b/src/lib/geogram/mesh/mesh_surface_intersection.cpp
@@ -339,7 +339,7 @@ namespace GEO {
             normalize_radius_ = -Numeric::max_float64();
             for(coord_index_t c=0; c<3; ++c) {
                 normalize_radius_ = std::max(
-                    normalize_radius_, 0.5*(xyz_max[1] - xyz_min[1])
+                    normalize_radius_, 0.5*(xyz_max[c] - xyz_min[c])
                 );
             }
             double s = 1.0/normalize_radius_;


### PR DESCRIPTION
Hello,

In `MeshSurfaceIntersection::intersect_prologue()`, there is a step to normalize the given mesh if requested. Currently, only the y-component is used to compute the radius. 

Any suggestion or modification is welcomed.