### PR TITLE
Replace deprecated std::atomic_init for C++20

### DIFF
--- a/src/lib/geogram/basic/thread_sync.h
+++ b/src/lib/geogram/basic/thread_sync.h
@@ -345,11 +345,10 @@ namespace GEO {
                     delete[] spinlocks_;
                     spinlocks_ = new std::atomic<uint32_t>[nb_words];
                     for(index_t i=0; i<nb_words; ++i) {
-                        // Note: std::atomic_init() is deprecated in C++20
-                        // that can initialize std::atomic through its
-                        // non-default constructor. We'll need to do something
-                        // else when we'll switch to C++20 (placement new...)
-                        std::atomic_init<uint32_t>(&spinlocks_[i],0u);
+                        // Note: std::atomic_init() is deprecated in C++20.
+                        // The array was just default-constructed by new[], so a
+                        // relaxed store is a safe single-threaded initialization.
+                        spinlocks_[i].store(0u, std::memory_order_relaxed);
                     }
                 }
 // Test at compile time that we are using atomic uint32_t operations (and not

--- a/src/lib/geogram/delaunay/delaunay_sync.h
+++ b/src/lib/geogram/delaunay/delaunay_sync.h
@@ -226,7 +226,7 @@ namespace GEO {
                     cell_status_t val = (i < size_) ?
                         old_cell_status[i].load(std::memory_order_relaxed) :
                         FREE_CELL;
-                    std::atomic_init(&cell_status_[i],val);
+                    cell_status_[i].store(val, std::memory_order_relaxed);
                 }
                 delete[] old_cell_status;
             }


### PR DESCRIPTION
## Summary

`std::atomic_init()` is deprecated in C++20. Compiling geogram (or a PSM extracted from it) with `-Werror=deprecated-declarations` — which several consumers do — turns this into a hard build error under C++20.

This replaces the three `std::atomic_init(&x, v)` call sites with `x.store(v, std::memory_order_relaxed)`:

- `src/lib/geogram/basic/thread_sync.h` (spinlock array)
- `src/lib/geogram/delaunay/delaunay_sync.h` (cell-status array)

In all cases the atomic array was just allocated via `new[]` (so the elements are already default-constructed) and is being initialized single-threaded, so a relaxed store is equivalent to the old `atomic_init` and removes the deprecated API. Builds cleanly from C++11 through C++20.

The existing comment in `thread_sync.h` ("We'll need to do something else when we switch to C++20") is updated accordingly.
