### PR TITLE
FIX: Remove SSE3 in Linux-clang.cmake

### DIFF
--- a/cmake/platforms/Linux-clang.cmake
+++ b/cmake/platforms/Linux-clang.cmake
@@ -36,10 +36,6 @@ add_flags(CMAKE_C_FLAGS -Wno-unknown-warning-option)
 #add_flags(CMAKE_CXX_FLAGS_RELEASE -D_FORTIFY_SOURCE=2)
 #add_flags(CMAKE_C_FLAGS_RELEASE -D_FORTIFY_SOURCE=2)
 
-# Enable SSE3 instruction set
-add_flags(CMAKE_CXX_FLAGS -msse3)
-add_flags(CMAKE_C_FLAGS -msse3)
-
 # Additional C++ flags
 add_flags(CMAKE_CXX_FLAGS -Qunused-arguments -Wno-c++98-compat)
 


### PR DESCRIPTION
Linux-clang.cmake unconditionally enables SSE3, which is obviously incompatible with non-x86 architectures.

However, Linux-clang.cmake is also included from Linux64-nonx86-clang-dynamic, which will then invoke the compiler with `-msse3`. This causes a compilation error if the target system is ARM and the compiler is Clang. The same would apply for GCC, but the relevant platform file does not add SSE3 flags.

This essentially matches Clang to the default behavior of GCC. If SSE3 is strictly needed (I don't see the point why Clang does and GCC doesn't however), it could be guarded behind something like this:
```cmake
if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|x64)")
  # Enable SSE3 instruction set
  add_flags(CMAKE_CXX_FLAGS -msse3)
  add_flags(CMAKE_C_FLAGS -msse3)
endif()
```