### PR TITLE
Delaunay/PDEL: fix locate_inexact() reading deleted-tet vertex slot

### DIFF
--- a/src/lib/geogram/delaunay/parallel_delaunay_3d.cpp
+++ b/src/lib/geogram/delaunay/parallel_delaunay_3d.cpp
@@ -1400,7 +1400,17 @@ namespace GEO {
         index_t locate_inexact(
             const double* p, index_t hint, index_t max_iter
         ) const {
-            // If no hint specified, find a tetrahedron randomly
+            //   If no hint was specified, or the specified hint refers to a
+            // tetrahedron that another thread freed/recycled in the meanwhile,
+            // find a tetrahedron randomly. Walking from a freed hint would
+            // immediately reach a deleted (or virtual) vertex slot and make
+            // this function -- and hence locate() -- give up; since the hint is
+            // not updated on failure, the insertion retry loop in run() would
+            // then spin on the same freed hint forever. Re-randomizing matches
+            // what locate() itself does when handed a freed hint.
+            if(hint != NO_TETRAHEDRON && tet_is_free(hint)) {
+                hint = NO_TETRAHEDRON;
+            }
             while(hint == NO_TETRAHEDRON) {
                 hint = thread_safe_random(max_used_t_);
                 if(tet_is_free(hint) || tet_thread(hint) != NO_THREAD) {
@@ -1438,11 +1448,21 @@ namespace GEO {
                 for(index_t lv=0; lv<4; ++lv) {
                     index_t iv = tet_vertex(t,lv);
 
-                    // Since we did not acquire any lock,
-                    // it is possible that another threads made
-                    // this tetrahedron virtual (in this case
-                    // we exit immediately).
-                    if(iv == NO_INDEX) {
+                    //   Since we did not acquire any lock, another thread
+                    // may have modified this tetrahedron in the meanwhile:
+                    // it may have made it virtual (the vertex slot becomes
+                    // VERTEX_AT_INFINITY == NO_INDEX) or deleted and recycled
+                    // it (in debug builds the slots are then poisoned to
+                    // VERTEX_OF_DELETED_TET). These are the two transient
+                    // states that this lock-free walk is expected to see, so
+                    // we just exit (the caller then falls back to the exact,
+                    // lock-acquiring locate()).
+                    //   We test for these two sentinels specifically rather
+                    // than for iv >= nb_vertices(), so that any *other*
+                    // out-of-range index (which would be a genuine error, not
+                    // a benign race) still trips the assertion in vertex_ptr()
+                    // instead of being silently ignored here.
+                    if(iv == NO_INDEX || iv == VERTEX_OF_DELETED_TET) {
                         return NO_TETRAHEDRON;
                     }
                     pv[lv] = vertex_ptr(iv);


### PR DESCRIPTION
Disclaimer: This fix was 100% authored by Claude - I might be totally wrong fix.
Fix for #367

Edit: Updated after force push.

ParallelDelaunay3d::locate_inexact() is a lock-free "structural filtering" walk: it reads tetrahedron data without acquiring any lock and is meant to tolerate concurrent modification (its result is only a hint, re-validated afterwards by the exact, lock-acquiring locate()). It did not, however, fully handle a tetrahedron that another thread freed and recycled, which caused two distinct failures on large inputs run with many threads.

1) Assertion / out-of-range read on the deleted-tet sentinel.
When the walk reads the vertices of a tetrahedron that another thread just deleted, in a GEO_DEBUG build those slots have been poisoned by insert() to VERTEX_OF_DELETED_TET (== index_t(-2)). The guard only tested iv == NO_INDEX (== index_t(-1)), so the sentinel slipped through into vertex_ptr(iv), tripping geo_debug_assert(i < nb_vertices()) (and, without the assert, forming an out-of-range address).
Fix: also bail out on VERTEX_OF_DELETED_TET. NO_INDEX (made virtual / cleared) and VERTEX_OF_DELETED_TET (deleted / recycled) are the only two non-vertex values a slot can legitimately hold during the lock-free walk; testing for exactly these two covers every benign transient while leaving any other out-of-range index to keep tripping the assertion in vertex_ptr() (a useful corruption tripwire) rather than silencing it.

2) Livelock when the starting hint was freed.
locate() passes its caller's hint straight to locate_inexact(). If that hint refers to a tetrahedron freed by another thread, locate_inexact() walked from it, immediately read a deleted/virtual slot and returned NO_TETRAHEDRON; locate() then returned NO_TETRAHEDRON too. insert() reports this as a failed locate *without* an interfering thread, so the retry loop in run() neither waits nor changes direction -- and since the hint is not updated on failure, it spins on the same freed hint forever (observed as one worker busy-looping in run() while the others finish).
Fix: if the supplied hint refers to a freed tetrahedron, drop it and pick a random one, exactly as locate() already does with a freed hint and as locate_inexact() already does with an unset hint.

In release builds a deleted tetrahedron keeps its (in-range) vertex indices until reused, so neither symptom occurs there; both are exposed by the debug poisoning interacting with the lock-free walk. The change is a no-op on the common path.

Reproduced reliably with a 19202-point convex-hull input on a 32-core machine: before, the assertion fired on nearly every run; with only fix (1) a run would instead livelock; with both fixes, 65/65 runs complete cleanly and the PDEL result is identical to the serial backend.
When the walk steps, via a stale tet_adjacent() link, onto a tetrahedron that another thread just deleted and put back on the free list, in a GEO_DEBUG build that tet's vertex slots have been poisoned to VERTEX_OF_DELETED_TET (== index_t(-2)) by insert(). Since VERTEX_OF_DELETED_TET != NO_INDEX, it passes the guard and reaches vertex_ptr(iv), where geo_debug_assert(i < nb_vertices()) fires (and, absent the assert, vertex_ptr() would form an out-of-range address).

Replace the `iv == NO_INDEX` guard with `iv >= nb_vertices()`, which covers NO_INDEX, VERTEX_OF_DELETED_TET and any other stale / out-of-range index in a single test, and bails out to the already-handled "could not get a hint, fall back to exact locate()" path. The check is a no-op on the common path (valid vertex indices are < nb_vertices()).

Reproduced reliably with a 19202-point convex-hull input on a 32-core machine: the assertion fired on nearly every run before this change and 0/32 runs after, and the PDEL result is identical to the serial backend.