### PR TITLE
Fix quadratic growth in MeshSubElementsStore::create_sub_elements()

### DIFF
--- a/src/lib/geogram/mesh/mesh.h
+++ b/src/lib/geogram/mesh/mesh.h
@@ -170,7 +170,7 @@ namespace GEO {
         if(nb_ + nb > attributes_.size()) {
             index_t new_capacity=nb_ + nb;
             if(nb < 128) {
-                new_capacity = std::max(index_t(16),attributes_.size());
+                new_capacity = std::max(index_t(16),attributes_.capacity());
                 while(new_capacity < nb_ + nb) {
                     new_capacity *= 2;
                 }


### PR DESCRIPTION
The capacity doubling loop started from attributes_.size() instead of attributes_.capacity(). Since size trails right behind capacity when elements are created one at a time, every create_sub_elements(1) call past the last reservation computed a new capacity a hair above the previous one, and AttributesManager::reserve() satisfied it with an exact reallocation - every attribute store (point coordinates included) was copied on every single-element create. Creating n elements one at a time therefore cost O(n^2); measured in practice as a Catmull-Clark subdivision producing 98k facets taking 55+ minutes instead of seconds.

Starting the doubling from attributes_.capacity() makes the reservation actually double, restoring amortized O(1) per-element creation. This matches the growth policy that the single-element create_sub_element() directly below already uses. Bulk creation (nb >= 128) is unchanged.

Fixes #371


Claude-Session: https://claude.ai/code/session_0153VSuZFxkzg9UdXjqLSzv7