### PR TITLE
Binding friendly api for Rosetta

### DIFF
--- a/src/lib/geogram/basic/attributes.cpp
+++ b/src/lib/geogram/basic/attributes.cpp
@@ -358,6 +358,44 @@ namespace GEO {
         return it->second;
     }
 
+    bool AttributesManager::get_doubles(
+        const std::string& name, vector<double>& out, index_t& dim
+    ) const {
+        const AttributeStore* store = find_attribute_store(name);
+        if(
+            store == nullptr ||
+            !store->elements_type_matches(typeid(double).name())
+        ) {
+            return false;
+        }
+        dim = store->dimension();
+        const double* p = static_cast<const double*>(store->data());
+        out.assign(p, p + store->size() * dim);
+        return true;
+    }
+
+    bool AttributesManager::set_doubles(
+        const std::string& name, const vector<double>& in, index_t dim
+    ) {
+        AttributeStore* store = find_attribute_store(name);
+        if(store == nullptr) {
+            if(in.size() != size_t(size()) * dim) {
+                return false;                    // do not create on size mismatch
+            }
+            store = new TypedAttributeStore<double>(dim);
+            bind_attribute_store(name, store);   // sizes it to size_, takes ownership
+        }
+        if(
+            !store->elements_type_matches(typeid(double).name()) ||
+            store->dimension() != dim ||
+            in.size() != size_t(store->size()) * dim
+        ) {
+            return false;
+        }
+        Memory::copy(store->data(), in.data(), in.size() * sizeof(double));
+        return true;
+    }
+
 
     void AttributesManager::delete_attribute_store(const std::string& name) {
         auto it = attributes_.find(name);

--- a/src/lib/geogram/basic/attributes.h
+++ b/src/lib/geogram/basic/attributes.h
@@ -1043,6 +1043,25 @@ namespace GEO {
     AttributeStore* find_attribute_store(const std::string& name);
 
     /**
+     * \brief Reads a double-typed attribute into a vector.
+     * \param[out] out receives size() * dim values.
+     * \param[out] dim the dimension of the attribute.
+     * \retval false if no attribute \p name exists or it is not double-typed.
+     */
+    bool get_doubles(
+        const std::string& name, vector<double>& out, index_t& dim
+    ) const;
+
+    /**
+     * \brief Writes a double-typed attribute, creating it if needed.
+     * \retval false on type or size mismatch
+     *  (in.size() must be size() * dim).
+     */
+    bool set_doubles(
+        const std::string& name, const vector<double>& in, index_t dim
+    );
+
+    /**
      * \brief Finds an AttributeStore by name.
      * \param[in] name the name under which the AttributeStore was bound
      * \return a const pointer to the attribute store or nullptr if is is

--- a/src/lib/geogram/basic/memory.h
+++ b/src/lib/geogram/basic/memory.h
@@ -45,6 +45,7 @@
 #include <geogram/basic/numeric.h>
 #include <geogram/basic/argused.h>
 #include <vector>
+#include <new>
 #include <string.h>
 #include <stdlib.h>
 

--- a/src/lib/geogram/mesh/mesh.h
+++ b/src/lib/geogram/mesh/mesh.h
@@ -3236,6 +3236,26 @@ namespace GEO {
         MeshElementsFlags what=MESH_ALL_ELEMENTS
     );
 
+    /**
+     * \brief Loads this mesh from a file.
+     * \details The file format is deduced from the extension. Supported
+     *  formats are those registered in the mesh I/O handlers
+     *  (.obj, .off, .ply, .stl, .mesh/.meshb, .geogram, ...).
+     *  Equivalent to mesh_load(filename, *this); implemented in
+     *  mesh_io.cpp.
+     * \param[in] filename the name of the file
+     * \retval true on success
+     */
+    bool load(const std::string& filename);
+
+    /**
+     * \brief Saves this mesh to a file.
+     * \details The file format is deduced from the extension.
+     *  Equivalent to mesh_save(*this, filename).
+     * \param[in] filename the name of the file
+     * \retval true on success
+     */
+    bool save(const std::string& filename) const;
 
     /**
      * \brief Gets the list of all attributes.

--- a/src/lib/geogram/mesh/mesh.h
+++ b/src/lib/geogram/mesh/mesh.h
@@ -107,7 +107,7 @@ namespace GEO {
      * \return a modifiable reference to the attributes manager.
      */
     AttributesManager& attributes() const {
-        return const_cast<AttributesManager&>(attributes_);
+        return attributes_;
     }
 
     /**
@@ -235,7 +235,7 @@ namespace GEO {
 
     protected:
     Mesh& mesh_;
-    AttributesManager attributes_;
+    mutable AttributesManager attributes_;
     index_t nb_;
     };
 
@@ -553,6 +553,32 @@ namespace GEO {
             geo_debug_assert(single_precision());
             return &point_fp32_[v*point_fp32_.dimension()];
         }
+
+        /**
+         * \brief Gets the coordinates of all the points as a single vector.
+         * \details The vector contains nb() * dimension() coordinates
+         *  [x0, y0, z0, x1, y1, z1, ...]. It is forbidden to change the
+         *  size of the returned vector; the reference is invalidated by
+         *  create_vertices() (same lifetime rule as point_ptr()).
+         * \return a const reference to the vector of all point coordinates.
+         * \pre !single_precision()
+         */
+        const vector<double>& point_coordinates() const {
+            geo_debug_assert(!single_precision());
+            return point_.get_vector();
+        }
+
+        /**
+         * \brief Gets the coordinates of all the points as a single vector.
+         * \return a modifiable reference to the vector of all point
+         *  coordinates (see the const overload for the contract).
+         * \pre !single_precision()
+         */
+        vector<double>& point_coordinates() {
+            geo_debug_assert(!single_precision());
+            return point_.get_vector();
+        }
+
 
         /**
          * \brief Assigns all the points.
@@ -1058,6 +1084,17 @@ namespace GEO {
         const index_t* vertex_index_ptr(index_t c) const {
             geo_debug_assert(c < nb());
             return &(corner_vertex_[c]);
+        }
+
+        /**
+         * \brief Gets the vertex indices of all corners as a single vector.
+         * \details On a triangulated mesh, this is the triangle list
+         *  (3 vertex indices per facet). It is forbidden to change the
+         *  size of the returned vector.
+         * \return a const reference to the corner-to-vertex table.
+         */
+        const vector<index_t>& vertex_indices() const {
+            return corner_vertex_;
         }
 
 	/**

--- a/src/lib/geogram/mesh/mesh_io.cpp
+++ b/src/lib/geogram/mesh/mesh_io.cpp
@@ -5114,4 +5114,12 @@ namespace GEO {
         return geogram.save(M, geofile, ioflags);
     }
 
+    bool Mesh::load(const std::string& filename) {
+        return mesh_load(filename, *this);
+    }
+
+    bool Mesh::save(const std::string& filename) const {
+        return mesh_save(*this, filename);
+    }
+
 }


### PR DESCRIPTION
Make the parts of the API that cannot cross a language-binding boundary
(reflection-based or hand-written) reachable from any scripting language,
without changing existing callers. Motivated by geogram-rosetta, which
generates Python/Node/WASM/TypeScript/Lua bindings from these headers.

- basic/memory.h: add missing #include <new> (std::get_new_handler is
  used but the header only arrives transitively on mainstream stdlibs)
- mesh/mesh.h: MeshVertices::point_coordinates() (const + non-const) —
  all coordinates as one sized contiguous vector (nb()*dimension()),
  the zero-copy shape every binding framework can marshal
- mesh/mesh.h: MeshFacetCornersStore::vertex_indices() — the whole
  corner-to-vertex table; on a triangulated mesh this is the triangle list
- mesh/mesh.h: MeshSubElementsStore::attributes_ declared mutable and the
  const_cast removed — expresses the documented mutable-through-const
  design legally, well-defined for a genuinely const Mesh
- basic/attributes.{h,cpp}: AttributesManager::get_doubles()/set_doubles()
  — type-erased read/write of double attributes by name, so scripting
  languages reach attribute data (e.g. tex_coord written by
  mesh_make_atlas) without instantiating the Attribute<double> template;
  set_doubles creates the attribute only after the size check
- mesh/mesh.h + mesh/mesh_io.cpp: member Mesh::load()/save() — the
  non-overloaded counterparts of the mesh_load/mesh_save overload sets
  (unnameable by reflection splicing, awkward even for pybind11)