### PR TITLE
Modify file system mounting logic in common.cpp to account for `NODERAWFS=1`

### DIFF
--- a/src/lib/geogram/basic/common.cpp
+++ b/src/lib/geogram/basic/common.cpp
@@ -146,9 +146,13 @@ namespace GEO {
                 // program runs in node.js.
                 // Current working directory is mounted in /working,
                 // and root directory is mounted in /root
+                //
+                // Skip this when NODERAWFS is enabled: the real filesystem is already
+                // mounted at '/', so FS.mkdir('/working') would try to create a directory
+                // at the real root and fail with EROFS (crashing worker pthreads).
 
                 EM_ASM(
-                    if(typeof module !== 'undefined' && this.module !== module) {
+                    if(typeof NODERAWFS === 'undefined' && typeof module !== 'undefined' && this.module !== module) {
                         FS.mkdir('/working');
                         FS.mkdir('/root');
                         FS.mount(NODEFS, { root: '.' }, '/working');


### PR DESCRIPTION
When using `NODERAWFS=1` (to let NodeJS directly write on disk), the code crashes because it tries to create a folder at the disk root, for example `/working`. So, I deactivate this if the disk is already mounted, and there is no need to create the folders.