### PR TITLE
[clang] Add _LIBCPP_REMOVE_TRANSITIVE_INCLUDES

### DIFF
--- a/cmake/geogram.cmake
+++ b/cmake/geogram.cmake
@@ -51,6 +51,13 @@ if(NOT DEFINED GEOGRAM_WITH_EXPLORAGRAM)
    endif()
 endif()
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      # Since C++23 libc++ is in the process of splitting larger headers into smaller modular headers.
+      # Force this behavior for the older dialects to keep the C++23 build green.
+      # See https://libcxx.llvm.org/DesignDocs/HeaderRemovalPolicy.html
+   add_definitions(-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES)
+endif()
+
 if (GEOGRAM_WITH_GEOGRAMPLUS)
    message(STATUS "addon: geogramplus")
    add_definitions(-DGEOGRAM_WITH_GEOGRAMPLUS)


### PR DESCRIPTION
follow-up to 43c8faecb7ff29dfff072a0a4f7361234299f32b

This adds `_LIBCPP_REMOVE_TRANSITIVE_INCLUDES` for Clang builds. Since libc++ is gradually splitting larger headers into smaller modular headers in C++23, this flag keeps older language dialects from breaking when transitive includes are removed. It matches the libc++ header-removal policy and helps keep the C++23 build green.