### PR TITLE
feat/fix: render volume-mesh cell_facets attributes and restore mesh color after surface borders

### DIFF
--- a/src/lib/geogram_gfx/gui/simple_mesh_application.cpp
+++ b/src/lib/geogram_gfx/gui/simple_mesh_application.cpp
@@ -490,6 +490,9 @@ namespace GEO {
 		index_t(surface_borders_width_*10.0f)
 	    );
             mesh_gfx_.draw_surface_borders();
+
+            // restore it so later passes (edges, volume wireframe) use the mesh color.
+            mesh_gfx_.set_mesh_color(mesh_color_.x, mesh_color_.y, mesh_color_.z);
         }
     }
 

--- a/src/lib/geogram_gfx/mesh/mesh_gfx.cpp
+++ b/src/lib/geogram_gfx/mesh/mesh_gfx.cpp
@@ -1124,14 +1124,18 @@ namespace GEO {
         if(attribute_subelements_ == MESH_CELL_FACETS &&
            picking_mode_ == MESH_NONE
         ) {
-            // The facets are drawn as surface primitives, on which GLUP
-            // does not apply the cells shrink; replicate it manually in
-            // draw_volume_cell_facets() and disable it here (GLUP's CPU
-            // immediate path would otherwise shrink each facet again).
             glupSetCellsShrink(0.0f);
-            for(index_t t: mesh_->cells) {
-                draw_volume_cell_facets(t);
-            }
+            draw_sequences(
+                mesh_->cells,
+                [&](index_t begin_c, index_t end_c) {
+                    draw_volume_cell_facets(
+                        begin_c, end_c, GLUP_TRIANGLES
+                    );
+                    draw_volume_cell_facets(
+                        begin_c, end_c, GLUP_QUADS
+                    );
+                }
+            );
             glupSetCellsShrink(GLUPfloat(shrink_));
         } else {
             draw_sequences(
@@ -1279,9 +1283,12 @@ namespace GEO {
                 [&](index_t c) { return index_t(mesh_->cells.type(c))==type; },
                 [&](index_t begin_c, index_t end_c) {
                     if(cell_facets) {
-                        for(index_t c=begin_c; c<end_c; ++c) {
-                            draw_volume_cell_facets(c);
-                        }
+                        draw_volume_cell_facets(
+                            begin_c, end_c, GLUP_TRIANGLES
+                        );
+                        draw_volume_cell_facets(
+                            begin_c, end_c, GLUP_QUADS
+                        );
                     } else {
                         glupBegin(geogram_cell_to_glup[type]);
                         for(index_t c=begin_c; c<end_c; ++c) {

--- a/src/lib/geogram_gfx/mesh/mesh_gfx.cpp
+++ b/src/lib/geogram_gfx/mesh/mesh_gfx.cpp
@@ -1121,24 +1121,38 @@ namespace GEO {
 
     void MeshGfx::draw_tets_immediate_attrib() {
         begin_attributes();
-        draw_sequences(
-            mesh_->cells,
-            [&](index_t begin_t, index_t end_t) {
-                glupBegin(GLUP_TETRAHEDRA);
-                for(index_t t=begin_t; t<end_t; ++t) {
-                    index_t c0 = 4*t;
-                    index_t v0 = mesh_->cells.vertex(t,0);
-                    index_t v1 = mesh_->cells.vertex(t,1);
-                    index_t v2 = mesh_->cells.vertex(t,2);
-                    index_t v3 = mesh_->cells.vertex(t,3);
-                    draw_volume_vertex_with_attribute(v0, t, c0);
-                    draw_volume_vertex_with_attribute(v1, t, c0+1);
-                    draw_volume_vertex_with_attribute(v2, t, c0+2);
-                    draw_volume_vertex_with_attribute(v3, t, c0+3);
-                }
-                glupEnd();
+        if(attribute_subelements_ == MESH_CELL_FACETS &&
+           picking_mode_ == MESH_NONE
+        ) {
+            // The facets are drawn as surface primitives, on which GLUP
+            // does not apply the cells shrink; replicate it manually in
+            // draw_volume_cell_facets() and disable it here (GLUP's CPU
+            // immediate path would otherwise shrink each facet again).
+            glupSetCellsShrink(0.0f);
+            for(index_t t: mesh_->cells) {
+                draw_volume_cell_facets(t);
             }
-        );
+            glupSetCellsShrink(GLUPfloat(shrink_));
+        } else {
+            draw_sequences(
+                mesh_->cells,
+                [&](index_t begin_t, index_t end_t) {
+                    glupBegin(GLUP_TETRAHEDRA);
+                    for(index_t t=begin_t; t<end_t; ++t) {
+                        index_t c0 = 4*t;
+                        index_t v0 = mesh_->cells.vertex(t,0);
+                        index_t v1 = mesh_->cells.vertex(t,1);
+                        index_t v2 = mesh_->cells.vertex(t,2);
+                        index_t v3 = mesh_->cells.vertex(t,3);
+                        draw_volume_vertex_with_attribute(v0, t, c0);
+                        draw_volume_vertex_with_attribute(v1, t, c0+1);
+                        draw_volume_vertex_with_attribute(v2, t, c0+2);
+                        draw_volume_vertex_with_attribute(v3, t, c0+3);
+                    }
+                    glupEnd();
+                }
+            );
+        }
         end_attributes();
     }
 
@@ -1248,6 +1262,14 @@ namespace GEO {
 
     void MeshGfx::draw_hybrid_immediate_attrib() {
         begin_attributes();
+        const bool cell_facets =
+            (attribute_subelements_ == MESH_CELL_FACETS &&
+             picking_mode_ == MESH_NONE);
+        if(cell_facets) {
+            // See draw_tets_immediate_attrib(): the facets are surface
+            // primitives, GLUP's cells shrink is replicated manually.
+            glupSetCellsShrink(0.0f);
+        }
         for(index_t type=MESH_TET; type < MESH_NB_CELL_TYPES; ++type) {
             if(!draw_cells_[type] || !has_cells_[type]) {
                 continue;
@@ -1256,20 +1278,29 @@ namespace GEO {
                 mesh_->cells,
                 [&](index_t c) { return index_t(mesh_->cells.type(c))==type; },
                 [&](index_t begin_c, index_t end_c) {
-                    glupBegin(geogram_cell_to_glup[type]);
-                    for(index_t c=begin_c; c<end_c; ++c) {
-                        index_t c0 = mesh_->cells.corners_begin(c);
-                        for(index_t lv=0;lv<mesh_->cells.nb_vertices(c);++lv) {
-                            draw_volume_vertex_with_attribute(
-                                mesh_->cells.vertex(c,lv),
-                                c,
-                                c0+lv
-                            );
+                    if(cell_facets) {
+                        for(index_t c=begin_c; c<end_c; ++c) {
+                            draw_volume_cell_facets(c);
                         }
+                    } else {
+                        glupBegin(geogram_cell_to_glup[type]);
+                        for(index_t c=begin_c; c<end_c; ++c) {
+                            index_t c0 = mesh_->cells.corners_begin(c);
+                            for(index_t lv=0;lv<mesh_->cells.nb_vertices(c);++lv) {
+                                draw_volume_vertex_with_attribute(
+                                    mesh_->cells.vertex(c,lv),
+                                    c,
+                                    c0+lv
+                                );
+                            }
+                        }
+                        glupEnd();
                     }
-                    glupEnd();
                 }
             );
+        }
+        if(cell_facets) {
+            glupSetCellsShrink(GLUPfloat(shrink_));
         }
         end_attributes();
     }

--- a/src/lib/geogram_gfx/mesh/mesh_gfx.h
+++ b/src/lib/geogram_gfx/mesh/mesh_gfx.h
@@ -747,6 +747,86 @@ namespace GEO {
         draw_vertex(vertex);
     }
 
+    void draw_volume_facet_vertex(
+        index_t cell, index_t lf, index_t lv, index_t cell_facet,
+        const double* centroid
+    ) {
+        draw_attribute_as_tex_coord(cell_facet);
+        const index_t v = mesh_->cells.facet_vertex(cell, lf, lv);
+        if(shrink_ == 0.0) {
+            draw_vertex(v);
+            return;
+        }
+        // GLUP only shrinks whole-cell primitives, so replicate the shrink
+        // by offsetting each facet vertex toward the cell centroid.
+        double p[3] = {0.0, 0.0, 0.0};
+        if(do_animation_) {
+            if(mesh_->vertices.single_precision()) {
+                const GLUPfloat* q =
+                    mesh_->vertices.single_precision_point_ptr(v);
+                const float t = float(time_);
+                const float s = 1.0f - float(time_);
+                p[0] = s*q[0] + t*q[3];
+                p[1] = s*q[1] + t*q[4];
+                p[2] = s*q[2] + t*q[5];
+            } else {
+                const double* q = mesh_->vertices.point_ptr(v);
+                const double s = 1.0 - time_;
+                p[0] = s*q[0] + time_*q[3];
+                p[1] = s*q[1] + time_*q[4];
+                p[2] = s*q[2] + time_*q[5];
+            }
+        } else {
+            const double* q = mesh_->vertices.point_ptr(v);
+            p[0] = q[0];
+            p[1] = q[1];
+            p[2] = q[2];
+        }
+        glupPrivateVertex3d(
+            (1.0 - shrink_) * p[0] + shrink_ * centroid[0],
+            (1.0 - shrink_) * p[1] + shrink_ * centroid[1],
+            (1.0 - shrink_) * p[2] + shrink_ * centroid[2]
+        );
+    }
+
+    void draw_volume_cell_facets(index_t c) {
+        // Draws the facets of cell c as independent triangle/quad
+        // primitives, with one tex coord per facet. This is needed for
+        // MESH_CELL_FACETS attributes, that have no per-vertex value.
+        double centroid[3] = {0.0, 0.0, 0.0};
+        if(shrink_ != 0.0) {
+            const index_t nb_v = mesh_->cells.nb_vertices(c);
+            for(index_t lv=0; lv<nb_v; ++lv) {
+                const double* p =
+                    mesh_->vertices.point_ptr(mesh_->cells.vertex(c, lv));
+                centroid[0] += p[0];
+                centroid[1] += p[1];
+                centroid[2] += p[2];
+            }
+            centroid[0] /= double(nb_v);
+            centroid[1] /= double(nb_v);
+            centroid[2] /= double(nb_v);
+        }
+        const index_t nb_facets = mesh_->cells.nb_facets(c);
+        for(index_t lf=0; lf<nb_facets; ++lf) {
+            const index_t cf = mesh_->cells.facet(c, lf);
+            const index_t nb_v = mesh_->cells.facet_nb_vertices(c, lf);
+            glupBegin(nb_v == 4 ? GLUP_QUADS : GLUP_TRIANGLES);
+            if(nb_v == 3 || nb_v == 4) {
+                for(index_t lv=0; lv<nb_v; ++lv) {
+                    draw_volume_facet_vertex(c, lf, lv, cf, centroid);
+                }
+            } else { // defensive fan for any unexpected facet size
+                for(index_t lv=1; lv+1<nb_v; ++lv) {
+                    for(index_t k: {index_t(0), lv, lv+1}) {
+                        draw_volume_facet_vertex(c, lf, k, cf, centroid);
+                    }
+                }
+            }
+            glupEnd();
+        }
+    }
+
     void draw_vertex(index_t v) {
         if(do_animation_) {
             if(mesh_->vertices.single_precision()) {

--- a/src/lib/geogram_gfx/mesh/mesh_gfx.h
+++ b/src/lib/geogram_gfx/mesh/mesh_gfx.h
@@ -789,42 +789,49 @@ namespace GEO {
         );
     }
 
-    void draw_volume_cell_facets(index_t c) {
-        // Draws the facets of cell c as independent triangle/quad
-        // primitives, with one tex coord per facet. This is needed for
-        // MESH_CELL_FACETS attributes, that have no per-vertex value.
-        double centroid[3] = {0.0, 0.0, 0.0};
-        if(shrink_ != 0.0) {
-            const index_t nb_v = mesh_->cells.nb_vertices(c);
-            for(index_t lv=0; lv<nb_v; ++lv) {
-                const double* p =
-                    mesh_->vertices.point_ptr(mesh_->cells.vertex(c, lv));
-                centroid[0] += p[0];
-                centroid[1] += p[1];
-                centroid[2] += p[2];
-            }
-            centroid[0] /= double(nb_v);
-            centroid[1] /= double(nb_v);
-            centroid[2] /= double(nb_v);
-        }
-        const index_t nb_facets = mesh_->cells.nb_facets(c);
-        for(index_t lf=0; lf<nb_facets; ++lf) {
-            const index_t cf = mesh_->cells.facet(c, lf);
-            const index_t nb_v = mesh_->cells.facet_nb_vertices(c, lf);
-            glupBegin(nb_v == 4 ? GLUP_QUADS : GLUP_TRIANGLES);
-            if(nb_v == 3 || nb_v == 4) {
+    void draw_volume_cell_facets(
+        index_t begin_c, index_t end_c, GLUPprimitive prim
+    ) {
+        glupBegin(prim);
+        for(index_t c=begin_c; c<end_c; ++c) {
+            double centroid[3] = {0.0, 0.0, 0.0};
+            if(shrink_ != 0.0) {
+                const index_t nb_v = mesh_->cells.nb_vertices(c);
                 for(index_t lv=0; lv<nb_v; ++lv) {
-                    draw_volume_facet_vertex(c, lf, lv, cf, centroid);
+                    const double* p =
+                        mesh_->vertices.point_ptr(mesh_->cells.vertex(c, lv));
+                    centroid[0] += p[0];
+                    centroid[1] += p[1];
+                    centroid[2] += p[2];
                 }
-            } else { // defensive fan for any unexpected facet size
-                for(index_t lv=1; lv+1<nb_v; ++lv) {
-                    for(index_t k: {index_t(0), lv, lv+1}) {
-                        draw_volume_facet_vertex(c, lf, k, cf, centroid);
+                centroid[0] /= double(nb_v);
+                centroid[1] /= double(nb_v);
+                centroid[2] /= double(nb_v);
+            }
+            const index_t nb_facets = mesh_->cells.nb_facets(c);
+            for(index_t lf=0; lf<nb_facets; ++lf) {
+                const index_t cf = mesh_->cells.facet(c, lf);
+                const index_t nb_v = mesh_->cells.facet_nb_vertices(c, lf);
+                if(prim == GLUP_QUADS) {
+                    if(nb_v == 4) {
+                        for(index_t lv=0; lv<4; ++lv) {
+                            draw_volume_facet_vertex(c, lf, lv, cf, centroid);
+                        }
+                    }
+                } else if(nb_v == 3) {
+                    for(index_t lv=0; lv<3; ++lv) {
+                        draw_volume_facet_vertex(c, lf, lv, cf, centroid);
+                    }
+                } else if(nb_v > 4) { // defensive fan for unexpected size
+                    for(index_t lv=1; lv+1<nb_v; ++lv) {
+                        for(index_t k: {index_t(0), lv, lv+1}) {
+                            draw_volume_facet_vertex(c, lf, k, cf, centroid);
+                        }
                     }
                 }
             }
-            glupEnd();
         }
+        glupEnd();
     }
 
     void draw_vertex(index_t v) {


### PR DESCRIPTION
Hi,

I made a few improvements/fixes to `geogram_gfx`:

### 1. Correct visualization of scalar attributes stored on `MESH_CELL_FACETS` of volume meshes

Previously, when displaying a scalar attribute stored on `MESH_CELL_FACETS`, the volume was rendered entirely in the colormap's first color. Root cause: `MeshGfx::draw_volume_vertex_with_attribute()` has branches for `MESH_VERTICES`, `MESH_CELLS` and `MESH_CELL_CORNERS`, but not for `MESH_CELL_FACETS` — GLUP texturing was enabled but no tex coord was ever emitted, so every fragment sampled the colormap at `t=0`.

When rendering cell-facet attributes: Since a vertex belongs to several facets of a cell, there is no unambiguous per-vertex value to attach the tex coord to, so the volume is now drawn facet by facet: each cell facet is emitted as its own `GLUP_TRIANGLES`/`GLUP_QUADS` primitive with a per-facet tex coord, reusing the same 1D-colormap setup as surface scalar attributes. The cells shrink slider is preserved by offsetting facet vertices toward the cell centroid (GLUP only shrinks whole-cell primitives, not surface ones).

The rendering speed of cell-facets is slightly slower compared to simply rendering cells, but I am not sure whether there is a better solution.

### 2. Restore the mesh color after drawing surface borders in `SimpleMeshApplication::draw_surface()`

After `mesh_gfx_.draw_surface_borders()`, `MeshGfx`'s mesh color is left set to the border color. The later passes (`draw_edges()` and the volume wireframe) then draw the volume-mesh edges with the border color, i.e. every edge looks like a border edge. I'm not 100% sure this is a bug rather than intended behavior, but it looked incorrect to me, so I restore the mesh color right after the border pass.