### PR TITLE
Missing <stdlib.h> in xatlas

### DIFF
--- a/src/lib/geogram/third_party/xatlas/xatlas.cpp
+++ b/src/lib/geogram/third_party/xatlas/xatlas.cpp
@@ -44,6 +44,7 @@ Copyright (c) 2012 Brandon Pelfrey
 #define __STDC_LIMIT_MACROS
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "xatlas.h"
 


### PR DESCRIPTION
xatlas.cpp uses realloc and free but includes no <stdlib.h>, relying on a transitive include that libc++ 23 (Homebrew LLVM 23.1.0) no longer provides. Same class of fix as 43c8fae for basic/memory.h.