### PR TITLE
FIX: Do not explicitly provide the lib/ search path in FindGeogram.cmake

### DIFF
--- a/cmake/FindGeogram.cmake
+++ b/cmake/FindGeogram.cmake
@@ -40,11 +40,13 @@ find_path (GEOGRAM_INCLUDE_DIR
 find_library (GEOGRAM_LIBRARY
                 NAMES geogram
                 PATHS ${GEOGRAM_SEARCH_PATHS}
+                PATH_SUFFIXES lib lib64
 )
 
 find_library (GEOGRAM_GFX_LIBRARY
                 NAMES geogram_gfx
                 PATHS ${GEOGRAM_SEARCH_PATHS}
+                PATH_SUFFIXES lib lib64
 )
 
 # This one we search in both Geogram search path and
@@ -53,6 +55,7 @@ find_library (GEOGRAM_GFX_LIBRARY
 find_library (GEOGRAM_GLFW3_LIBRARY
                 NAMES glfw3 glfw geogram_glfw3 glfw3dll glfwdll
                 PATHS ${GEOGRAM_SEARCH_PATHS} ${GEOGRAM_SEARCH_PATHS_SYSTEM}
+                PATH_SUFFIXES lib lib64
 )
 
 include (FindPackageHandleStandardArgs)

--- a/cmake/FindGeogram.cmake
+++ b/cmake/FindGeogram.cmake
@@ -40,13 +40,11 @@ find_path (GEOGRAM_INCLUDE_DIR
 find_library (GEOGRAM_LIBRARY
                 NAMES geogram
                 PATHS ${GEOGRAM_SEARCH_PATHS}
-                PATH_SUFFIXES lib
 )
 
 find_library (GEOGRAM_GFX_LIBRARY
                 NAMES geogram_gfx
                 PATHS ${GEOGRAM_SEARCH_PATHS}
-                PATH_SUFFIXES lib
 )
 
 # This one we search in both Geogram search path and
@@ -55,7 +53,6 @@ find_library (GEOGRAM_GFX_LIBRARY
 find_library (GEOGRAM_GLFW3_LIBRARY
                 NAMES glfw3 glfw geogram_glfw3 glfw3dll glfwdll
                 PATHS ${GEOGRAM_SEARCH_PATHS} ${GEOGRAM_SEARCH_PATHS_SYSTEM}
-                PATH_SUFFIXES lib
 )
 
 include (FindPackageHandleStandardArgs)


### PR DESCRIPTION
On our platform, the geogram library is installed under *lib64/*. Since the *lib/* suffix is hardcoded in FindGeogram.cmake, geogram is not found.

https://github.com/BrunoLevy/geogram/blob/f65dca074d06a60dfce29a9f6c9e7219103ab039/cmake/FindGeogram.cmake#L40-L44

I propose not to set `PATH_SUFFIXES` since CMake automatically searches it according to the [documentation](https://cmake.org/cmake/help/latest/command/find_library.html):

> If the [FIND_LIBRARY_USE_LIB64_PATHS](https://cmake.org/cmake/help/latest/prop_gbl/FIND_LIBRARY_USE_LIB64_PATHS.html#prop_gbl:FIND_LIBRARY_USE_LIB64_PATHS) global property is set all search paths will be tested as normal, with 64/ appended, and with all matches of lib/ replaced with lib64/. This property is automatically set for the platforms that are known to need it if at least one of the languages supported by the [project()](https://cmake.org/cmake/help/latest/command/project.html#command:project) command is enabled.

Indeed, you can see it yourself if you print `FIND_LIBRARY_USE_LIB64_PATHS` in one of the CMake scripts:
```
message(${FIND_LIBRARY_USE_LIB64_PATHS})  # will print TRUE on 64 bit platforms
```
Alternatively, although I recommend not providing `PATH_SUFFIXES`, you can add `lib64`:
```
PATH_SUFFIXES lib lib64
```
I tested both variants on my Linux system.

I modified the other two occurrences of `find_library` in this PR, but I couldn't test them because I use the minimum geogram build.